### PR TITLE
Add link to IHP SG13G2 Process specification for direkt access

### DIFF
--- a/docs/layout_rules/01_general.rst
+++ b/docs/layout_rules/01_general.rst
@@ -32,4 +32,4 @@ Layout Information
 Reference documents
 -------------------
 
-[RD 1] IHP SG13G2 Process specification Rev. 1.2
+[RD 1] `IHP SG13G2 Process specification Rev. 1.2 <https://raw.githubusercontent.com/IHP-GmbH/IHP-Open-PDK/main/ihp-sg13g2/libs.doc/doc/SG13G2_os_process_spec.pdf>`_


### PR DESCRIPTION
Updated reference link for IHP SG13G2 Process specification.